### PR TITLE
usuário logado consegue visualizar uma publicação correspondente a um outro usuário

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ back/knexfile.js
 static/uploads/
 
 back/static/uploads/
+
+.vscode/

--- a/back/src/controllers/publicationController.js
+++ b/back/src/controllers/publicationController.js
@@ -42,10 +42,12 @@ class publicationController {
 
   async list(req, res){
     
+    const { idUsuario } = req.params;
+
     const user_publications = await knex.select('*')
     .from('publicacao')
     .join('imagem', 'publicacao.idPublicacao', 'imagem.idPublicacao')
-    .where({ idUsuario: req.body.idUsuario });
+    .where({ idUsuario: idUsuario });
 
     return res.json(user_publications);
   }

--- a/back/src/controllers/publicationController.js
+++ b/back/src/controllers/publicationController.js
@@ -56,6 +56,8 @@ class publicationController {
     
     const { idUsuario, idPublicacao} = req.params;
 
+    if(idUsuario != req.body.idUsuario) return res.status(400).send({error: "Você nao pode apagar publicações que não são suas"});
+
     const photos = await knex.select('imagem.nomeImagem')
     .from('publicacao')
     .join('imagem', 'publicacao.idPublicacao', 'imagem.idPublicacao')

--- a/back/src/controllers/publicationController.js
+++ b/back/src/controllers/publicationController.js
@@ -31,7 +31,7 @@ class publicationController {
     .returning('idPublicacao').then(async function (idPublicacao){
 
       for (const img of req.files) {
-        const file_path = __dirname + img.path;
+        const file_path = img.path;
         await knex('imagem')
         .insert({ nomeImagem: file_path, idPublicacao: idPublicacao[0]});
       }
@@ -55,6 +55,13 @@ class publicationController {
   async delete(req, res, next){
     
     const { idUsuario, idPublicacao} = req.params;
+
+    const photos = await knex.select('imagem.nomeImagem')
+    .from('publicacao')
+    .join('imagem', 'publicacao.idPublicacao', 'imagem.idPublicacao')
+    .where({ idUsuario: idUsuario });
+
+    for (const photo of photos) await unlinkAsync(photo.nomeImagem);
 
     await knex('publicacao').where({ 
       idUsuario: idUsuario, 

--- a/back/src/routes.js
+++ b/back/src/routes.js
@@ -39,7 +39,7 @@ router.post('/login', loginController.login);
 
 router.post('/nova_publicacao', [authServices.middlewares, upload.any()], publicationController.store);
 router.get('/:idUsuario/publicacoes', authServices.middlewares, publicationController.list);
-router.delete('/usuario/:idUsuario/publicacao/:idPublicacao', publicationController.delete)
+router.delete('/usuario/:idUsuario/publicacao/:idPublicacao', authServices.middlewares, publicationController.delete)
 
 //alterar e deletar usuarios
 router.delete('/usuario/:idUsuario', UserController.delete)

--- a/back/src/routes.js
+++ b/back/src/routes.js
@@ -38,7 +38,7 @@ router.get('/login', (req, res) => res.send('Logar'));
 router.post('/login', loginController.login);
 
 router.post('/nova_publicacao', [authServices.middlewares, upload.any()], publicationController.store);
-router.get('/publicacoes', authServices.middlewares, publicationController.list);
+router.get('/:idUsuario/publicacoes', authServices.middlewares, publicationController.list);
 router.delete('/usuario/:idUsuario/publicacao/:idPublicacao', publicationController.delete)
 
 //alterar e deletar usuarios


### PR DESCRIPTION
algumas alterações foram feitas tambem na rota de deletar publicação. a primeira é que um usuário só pode deletar uma publicação caso ele esteja autenticado e a publicação seja sua. Outra  alteração é que as imagens relacionadas a publicação são excluidas do servidor, antes, apenas as informações contidas no banco de dados eram excluidas